### PR TITLE
Add interfaces IMulticastService and IServiceDiscovery

### DIFF
--- a/src/IMulticastService.cs
+++ b/src/IMulticastService.cs
@@ -1,0 +1,266 @@
+﻿using System;
+using System.Net.Sockets;
+
+namespace Makaretu.Dns
+{
+    /// <summary>
+    ///   Muticast Domain Name Service.
+    /// </summary>
+    /// <remarks>
+    ///   Sends and receives DNS queries and answers via the multicast mechanism
+    ///   defined in <see href="https://tools.ietf.org/html/rfc6762"/>.
+    ///   <para>
+    ///   Use <see cref="Start"/> to start listening for multicast messages.
+    ///   One of the events, <see cref="QueryReceived"/> or <see cref="AnswerReceived"/>, is
+    ///   raised when a <see cref="Message"/> is received.
+    ///   </para>
+    /// </remarks>
+    public interface IMulticastService : IResolver, IDisposable
+    {
+        /// <summary>
+        ///   Raised when any local MDNS service sends a query.
+        /// </summary>
+        /// <value>
+        ///   Contains the query <see cref="Message"/>.
+        /// </value>
+        /// <remarks>
+        ///   Any exception throw by the event handler is simply logged and
+        ///   then forgotten.
+        /// </remarks>
+        /// <seealso cref="SendQuery(Message)"/>
+        public event EventHandler<MessageEventArgs> QueryReceived;
+
+        /// <summary>
+        ///   Raised when any link-local MDNS service responds to a query.
+        /// </summary>
+        /// <value>
+        ///   Contains the answer <see cref="Message"/>.
+        /// </value>
+        /// <remarks>
+        ///   Any exception throw by the event handler is simply logged and
+        ///   then forgotten.
+        /// </remarks>
+        public event EventHandler<MessageEventArgs> AnswerReceived;
+
+        /// <summary>
+        ///   Raised when a DNS message is received that cannot be decoded.
+        /// </summary>
+        /// <value>
+        ///   The DNS message as a byte array.
+        /// </value>
+        public event EventHandler<byte[]> MalformedMessage;
+
+        /// <summary>
+        ///   Raised when one or more network interfaces are discovered.
+        /// </summary>
+        /// <value>
+        ///   Contains the network interface(s).
+        /// </value>
+        public event EventHandler<NetworkInterfaceEventArgs> NetworkInterfaceDiscovered;
+
+        /// <summary>
+        ///   Send and receive on IPv4.
+        /// </summary>
+        /// <value>
+        ///   Defaults to <b>true</b> if the OS supports it.
+        /// </value>
+        public bool UseIpv4 { get; set; }
+
+        /// <summary>
+        ///   Send and receive on IPv6.
+        /// </summary>
+        /// <value>
+        ///   Defaults to <b>true</b> if the OS supports it.
+        /// </value>
+        public bool UseIpv6 { get; set; }
+
+        /// <summary>
+        ///   Determines if received messages are checked for duplicates.
+        /// </summary>
+        /// <value>
+        ///   <b>true</b> to ignore duplicate messages. Defaults to <b>true</b>.
+        /// </value>
+        /// <remarks>
+        ///   When set, a message that has been received within the last minute
+        ///   will be ignored.
+        /// </remarks>
+        public bool IgnoreDuplicateMessages { get; set; }
+
+        /// <summary>
+        ///   Start the service.
+        /// </summary>
+        public void Start();
+
+        /// <summary>
+        ///   Stop the service.
+        /// </summary>
+        /// <remarks>
+        ///   Clears all the event handlers.
+        /// </remarks>
+        public void Stop();
+
+        /// <summary>
+        ///   Ask for answers about a name.
+        /// </summary>
+        /// <param name="name">
+        ///   A domain name that should end with ".local", e.g. "myservice.local".
+        /// </param>
+        /// <param name="class">
+        ///   The class, defaults to <see cref="DnsClass.IN"/>.
+        /// </param>
+        /// <param name="type">
+        ///   The question type, defaults to <see cref="DnsType.ANY"/>.
+        /// </param>
+        /// <remarks>
+        ///   Answers to any query are obtained on the <see cref="AnswerReceived"/>
+        ///   event.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        ///   When the service has not started.
+        /// </exception>
+        public void SendQuery(DomainName name, DnsClass @class = DnsClass.IN, DnsType type = DnsType.ANY);
+
+        /// <summary>
+        ///   Ask for answers about a name and accept unicast and/or broadcast response.
+        /// </summary>
+        /// <param name="name">
+        ///   A domain name that should end with ".local", e.g. "myservice.local".
+        /// </param>
+        /// <param name="class">
+        ///   The class, defaults to <see cref="DnsClass.IN"/>.
+        /// </param>
+        /// <param name="type">
+        ///   The question type, defaults to <see cref="DnsType.ANY"/>.
+        /// </param>
+        /// <remarks>
+        ///   Send a "QU" question (unicast). The most significant bit of the Class is set.
+        ///   Answers to any query are obtained on the <see cref="AnswerReceived"/>
+        ///   event.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        ///   When the service has not started.
+        /// </exception>
+        public void SendUnicastQuery(DomainName name, DnsClass @class = DnsClass.IN, DnsType type = DnsType.ANY);
+
+        /// <summary>
+        ///   Ask for answers.
+        /// </summary>
+        /// <param name="msg">
+        ///   A query message.
+        /// </param>
+        /// <remarks>
+        ///   Answers to any query are obtained on the <see cref="AnswerReceived"/>
+        ///   event.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        ///   When the service has not started.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   When the serialized <paramref name="msg"/> is too large.
+        /// </exception>
+        public void SendQuery(Message msg);
+
+        /// <summary>
+        ///   Send an answer to a query.
+        /// </summary>
+        /// <param name="answer">
+        ///   The answer message.
+        /// </param>
+        /// <param name="checkDuplicate">
+        ///   If <b>true</b>, then if the same <paramref name="answer"/> was
+        ///   recently sent it will not be sent again.
+        /// </param>
+        /// <exception cref="InvalidOperationException">
+        ///   When the service has not started.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   When the serialized <paramref name="answer"/> is too large.
+        /// </exception>
+        /// <remarks>
+        ///   <para>
+        ///   The <see cref="Message.AA"/> flag is set to true,
+        ///   the <see cref="Message.Id"/> set to zero and any questions are removed.
+        ///   </para>
+        ///   <para>
+        ///   The <paramref name="answer"/> is <see cref="Message.Truncate">truncated</see>
+        ///   if exceeds the maximum packet length.
+        ///   </para>
+        ///   <para>
+        ///   <paramref name="checkDuplicate"/> should always be <b>true</b> except
+        ///   when <see href="https://tools.ietf.org/html/rfc6762#section-8.1">answering a probe</see>.
+        ///   </para>
+        ///   <note type="caution">
+        ///   If possible the <see cref="SendAnswer(Message, MessageEventArgs, bool)"/>
+        ///   method should be used, so that legacy unicast queries are supported.
+        ///   </note>
+        /// </remarks>
+        /// <see cref="QueryReceived"/>
+        /// <seealso cref="Message.CreateResponse"/>
+        public void SendAnswer(Message answer, bool checkDuplicate = true);
+
+        /// <summary>
+        ///   Send an answer to a query.
+        /// </summary>
+        /// <param name="answer">
+        ///   The answer message.
+        /// </param>
+        /// <param name="query">
+        ///   The query that is being answered.
+        /// </param>
+        /// <param name="checkDuplicate">
+        ///   If <b>true</b>, then if the same <paramref name="answer"/> was
+        ///   recently sent it will not be sent again.
+        /// </param>
+        /// <exception cref="InvalidOperationException">
+        ///   When the service has not started.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   When the serialized <paramref name="answer"/> is too large.
+        /// </exception>
+        /// <remarks>
+        ///   <para>
+        ///   If the <paramref name="query"/> is a standard multicast query (sent to port 5353), then
+        ///   <see cref="SendAnswer(Message, bool)"/> is called.
+        ///   </para>
+        ///   <para>
+        ///   Otherwise a legacy unicast response is sent to sender's end point.
+        ///   The <see cref="Message.AA"/> flag is set to true,
+        ///   the <see cref="Message.Id"/> is set to query's ID,
+        ///   the <see cref="Message.Questions"/> is set to the query's questions,
+        ///   and all resource record TTLs have a max value of 10 seconds.
+        ///   </para>
+        ///   <para>
+        ///   The <paramref name="answer"/> is <see cref="Message.Truncate">truncated</see>
+        ///   if exceeds the maximum packet length.
+        ///   </para>
+        ///   <para>
+        ///   <paramref name="checkDuplicate"/> should always be <b>true</b> except
+        ///   when <see href="https://tools.ietf.org/html/rfc6762#section-8.1">answering a probe</see>.
+        ///   </para>
+        /// </remarks>
+        public void SendAnswer(Message answer, MessageEventArgs query, bool checkDuplicate = true);
+
+        /// <summary>
+        ///   Called by the MulticastClient when a DNS message is received.
+        /// </summary>
+        /// <param name="sender">
+        ///   The <see cref="MulticastClient"/> that got the message.
+        /// </param>
+        /// <param name="result">
+        ///   The received message <see cref="UdpReceiveResult"/>.
+        /// </param>
+        /// <remarks>
+        ///   Decodes the <paramref name="result"/> and then raises
+        ///   either the <see cref="QueryReceived"/> or <see cref="AnswerReceived"/> event.
+        ///   <para>
+        ///   Multicast DNS messages received with an OPCODE or RCODE other than zero
+        ///   are silently ignored.
+        ///   </para>
+        ///   <para>
+        ///   If the message cannot be decoded, then the <see cref="MalformedMessage"/>
+        ///   event is raised.
+        ///   </para>
+        /// </remarks>
+        public void OnDnsMessage(object sender, UdpReceiveResult result);
+    }
+}

--- a/src/IServiceDiscovery.cs
+++ b/src/IServiceDiscovery.cs
@@ -1,0 +1,196 @@
+﻿using System;
+using Makaretu.Dns.Resolving;
+
+namespace Makaretu.Dns
+{
+    /// <summary>
+    ///   DNS based Service Discovery is a way of using standard DNS programming interfaces, servers,
+    ///   and packet formats to browse the network for services.
+    /// </summary>
+    /// <seealso href="https://tools.ietf.org/html/rfc6763">RFC 6763 DNS-Based Service Discovery</seealso>
+    public interface IServiceDiscovery : IDisposable
+    {
+        /// <summary>
+        ///   Gets the multicasting service.
+        /// </summary>
+        /// <value>
+        ///   Is used to send and receive multicast <see cref="Message">DNS messages</see>.
+        /// </value>
+        public IMulticastService Mdns { get; }
+
+        /// <summary>
+        ///   Add the additional records into the answers.
+        /// </summary>
+        /// <value>
+        ///   Defaults to <b>false</b>.
+        /// </value>
+        /// <remarks>
+        ///   Some malformed systems, such as js-ipfs and go-ipfs, only examine
+        ///   the <see cref="Message.Answers"/> and not the <see cref="Message.AdditionalRecords"/>.
+        ///   Setting this to <b>true</b>, will move the additional records
+        ///   into the answers.
+        ///   <para>
+        ///   This never done for DNS-SD answers.
+        ///   </para>
+        /// </remarks>
+        public bool AnswersContainsAdditionalRecords { get; set; }
+
+        /// <summary>
+        ///   Gets the name server.
+        /// </summary>
+        /// <value>
+        ///   Is used to answer questions.
+        /// </value>
+        public NameServer NameServer { get; }
+
+        /// <summary>
+        ///   Raised when a DNS-SD response is received.
+        /// </summary>
+        /// <value>
+        ///   Contains the service name.
+        /// </value>
+        /// <remarks>
+        ///   <b>ServiceDiscovery</b> passively monitors the network for any answers
+        ///   to a DNS-SD query. When an answer is received this event is raised.
+        ///   <para>
+        ///   Use <see cref="QueryAllServices"/> to initiate a DNS-SD question.
+        ///   </para>
+        /// </remarks>
+        public event EventHandler<DomainName> ServiceDiscovered;
+
+        /// <summary>
+        ///   Raised when a service instance is discovered.
+        /// </summary>
+        /// <value>
+        ///   Contains the service instance name.
+        /// </value>
+        /// <remarks>
+        ///   <b>ServiceDiscovery</b> passively monitors the network for any answers.
+        ///   When an answer containing a PTR to a service instance is received
+        ///   this event is raised.
+        /// </remarks>
+        public event EventHandler<ServiceInstanceDiscoveryEventArgs> ServiceInstanceDiscovered;
+
+        /// <summary>
+        ///   Raised when a service instance is shutting down.
+        /// </summary>
+        /// <value>
+        ///   Contains the service instance name.
+        /// </value>
+        /// <remarks>
+        ///   <b>ServiceDiscovery</b> passively monitors the network for any answers.
+        ///   When an answer containing a PTR to a service instance with a
+        ///   TTL of zero is received this event is raised.
+        /// </remarks>
+        public event EventHandler<ServiceInstanceShutdownEventArgs> ServiceInstanceShutdown;
+
+        /// <summary>
+        ///    Asks other MDNS services to send their service names.
+        /// </summary>
+        /// <remarks>
+        ///   When an answer is received the <see cref="ServiceDiscovered"/> event is raised.
+        /// </remarks>
+        public void QueryAllServices();
+
+        /// <summary>
+        ///    Asks other MDNS services to send their service names;
+        ///    accepts unicast and/or broadcast answers.
+        /// </summary>
+        /// <remarks>
+        ///   When an answer is received the <see cref="ServiceDiscovered"/> event is raised.
+        /// </remarks>
+        public void QueryUnicastAllServices();
+
+        /// <summary>
+        ///   Asks instances of the specified service to send details.
+        /// </summary>
+        /// <param name="service">
+        ///   The service name to query. Typically of the form "_<i>service</i>._tcp".
+        /// </param>
+        /// <remarks>
+        ///   When an answer is received the <see cref="ServiceInstanceDiscovered"/> event is raised.
+        /// </remarks>
+        /// <seealso cref="ServiceProfile.ServiceName"/>
+        public void QueryServiceInstances(DomainName service);
+
+        /// <summary>
+        ///   Asks instances of the specified service with the subtype to send details.
+        /// </summary>
+        /// <param name="service">
+        ///   The service name to query. Typically of the form "_<i>service</i>._tcp".
+        /// </param>
+        /// <param name="subtype">
+        ///   The feature that is needed.
+        /// </param>
+        /// <remarks>
+        ///   When an answer is received the <see cref="ServiceInstanceDiscovered"/> event is raised.
+        /// </remarks>
+        /// <seealso cref="ServiceProfile.ServiceName"/>
+        public void QueryServiceInstances(DomainName service, string subtype);
+
+        /// <summary>
+        ///   Asks instances of the specified service to send details.
+        ///   accepts unicast and/or broadcast answers.
+        /// </summary>
+        /// <param name="service">
+        ///   The service name to query. Typically of the form "_<i>service</i>._tcp".
+        /// </param>
+        /// <remarks>
+        ///   When an answer is received the <see cref="ServiceInstanceDiscovered"/> event is raised.
+        /// </remarks>
+        /// <seealso cref="ServiceProfile.ServiceName"/>
+        public void QueryUnicastServiceInstances(DomainName service);
+
+        /// <summary>
+        ///   Advertise a service profile.
+        /// </summary>
+        /// <param name="service">
+        ///   The service profile.
+        /// </param>
+        /// <remarks>
+        ///   Any queries for the service or service instance will be answered with
+        ///   information from the profile.
+        ///   <para>
+        ///   Besides adding the profile's resource records to the <see cref="Catalog"/> PTR records are
+        ///   created to support DNS-SD and reverse address mapping (DNS address lookup).
+        ///   </para>
+        /// </remarks>
+        public void Advertise(ServiceProfile service);
+
+        /// <summary>
+        /// Probe the network to ensure the service is unique.
+        /// </summary>
+        /// <param name="profile"></param>
+        /// <returns>True if this service conflicts with an existing network service</returns>
+        public bool Probe(ServiceProfile profile);
+
+        /// <summary>
+        ///    Sends an unsolicited MDNS response describing the
+        ///    service profile.
+        /// </summary>
+        /// <param name="profile">
+        ///   The profile to describe.
+        /// </param>
+        /// <remarks>
+        ///   Sends a MDNS response <see cref="Message"/> containing the pointer
+        ///   and resource records of the <paramref name="profile"/>.
+        ///   <para>
+        ///   To provide increased robustness against packet loss,
+        ///   two unsolicited responses are sent one second apart.
+        ///   </para>
+        /// </remarks>
+        public void Announce(ServiceProfile profile);
+
+        /// <summary>
+        /// Sends a goodbye message for the provided
+        /// profile and removes its pointer from the name sever.
+        /// </summary>
+        /// <param name="profile">The profile to send a goodbye message for.</param>
+        public void Unadvertise(ServiceProfile profile);
+
+        /// <summary>
+        /// Sends a goodbye message for each announced service.
+        /// </summary>
+        public void Unadvertise();
+    }
+}


### PR DESCRIPTION
Unit testing frameworks (e.g. [Moq](https://github.com/moq/moq4) or [FakeItEasy](https://github.com/FakeItEasy/FakeItEasy)) can mock referenced classes in order to achieve a specific behaviour. In order to do so, the classes need to provide an overridable implementation. This can be achieved by either providing an interface or declaring members virtual.

This PR adds the interfaces IMulticastService and IServiceDiscovery to be able to mock the instances for unit testing.