### PR TITLE
Fix multicast responses not being sent out on all interfaces

### DIFF
--- a/LaurieTest/LaurieTest.csproj
+++ b/LaurieTest/LaurieTest.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Mdns.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/LaurieTest/Program.cs
+++ b/LaurieTest/Program.cs
@@ -1,0 +1,16 @@
+﻿using Makaretu.Dns;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+
+var mdnsService = new ServiceProfile("10.0.1.50", "_videohub._tcp", 9990);
+var mdnsService2 = new ServiceProfile("10.0.1.50", "_blackmagic._tcp", 9990);
+var sd = new ServiceDiscovery();
+sd.Advertise(mdnsService);
+sd.Advertise(mdnsService2);
+while (true) {
+	Console.WriteLine("Advertise");
+	sd.Announce(mdnsService);
+	sd.Announce(mdnsService2);
+	Thread.Sleep(5000);
+}

--- a/LaurieTest/appsettings.json
+++ b/LaurieTest/appsettings.json
@@ -1,0 +1,16 @@
+{
+  "exclude": [
+    "**/bin",
+    "**/bower_components",
+    "**/jspm_packages",
+    "**/node_modules",
+    "**/obj",
+    "**/platforms"
+  ],
+  "Logging": {
+    "LogLevel": {
+      "Makaretu.Dns": "Trace",
+      "Default": "Trace"
+    }
+  }
+}

--- a/Mdns.sln
+++ b/Mdns.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2027
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33110.190
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6B9AA9C7-5E90-4D10-9DDE-A2AA5FE3ECA6}"
 	ProjectSection(SolutionItems) = preProject
@@ -24,7 +24,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Spike", "Spike\Spike.csproj
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Browser", "Browser\Browser.csproj", "{A77BEF8C-440E-46F7-ACFC-5EF06EFCA4BA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "traffic", "traffic\traffic.csproj", "{5E51D502-05E1-4A45-A8D6-6FB3E295D798}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "traffic", "traffic\traffic.csproj", "{5E51D502-05E1-4A45-A8D6-6FB3E295D798}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LaurieTest", "LaurieTest\LaurieTest.csproj", "{A7142280-C2C4-4204-91DE-F7DD37B347CB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -54,6 +56,10 @@ Global
 		{5E51D502-05E1-4A45-A8D6-6FB3E295D798}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5E51D502-05E1-4A45-A8D6-6FB3E295D798}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5E51D502-05E1-4A45-A8D6-6FB3E295D798}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A7142280-C2C4-4204-91DE-F7DD37B347CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7142280-C2C4-4204-91DE-F7DD37B347CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7142280-C2C4-4204-91DE-F7DD37B347CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7142280-C2C4-4204-91DE-F7DD37B347CB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Mdns.csproj
+++ b/src/Mdns.csproj
@@ -30,7 +30,13 @@
   <ItemGroup>
     <PackageReference Include="Common.Logging" Version="3.4.1" />
     <PackageReference Include="Makaretu.Dns.New" Version="3.0.1" />
-	<None Include="..\README.md" Pack="true" PackagePath="\"/>
+	<None Include="..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/MulticastClient.cs
+++ b/src/MulticastClient.cs
@@ -78,10 +78,12 @@ namespace Makaretu.Dns
                     switch (address.AddressFamily)
                     {
                         case AddressFamily.InterNetwork:
-                            receiver4.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, new MulticastOption(MulticastAddressIp4, address));
+                            MulticastOption mcastOption = new MulticastOption(MulticastAddressIp4, address);
+
+                            receiver4.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, mcastOption);
                             sender.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
                             sender.Client.Bind(localEndpoint);
-                            sender.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, new MulticastOption(MulticastAddressIp4));
+                            sender.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, mcastOption);
                             sender.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastLoopback, true);
                             break;
                         case AddressFamily.InterNetworkV6:

--- a/src/MulticastService.cs
+++ b/src/MulticastService.cs
@@ -275,7 +275,7 @@ namespace Makaretu.Dns
 
         private void FindNetworkInterfaces()
         {
-            log.Debug("Finding network interfaces");
+            Console.WriteLine("Finding network interfaces");
 
             try
             {
@@ -290,7 +290,7 @@ namespace Makaretu.Dns
 
                     if (log.IsDebugEnabled)
                     {
-                        log.Debug($"Removed nic '{nic.Name}'.");
+                        Console.WriteLine($"Removed nic '{nic.Name}'.");
                     }
                 }
 
@@ -300,7 +300,7 @@ namespace Makaretu.Dns
 
                     if (log.IsDebugEnabled)
                     {
-                        log.Debug($"Found nic '{nic.Name}'.");
+                        Console.WriteLine($"Found nic '{nic.Name}'.");
                     }
                 }
 

--- a/src/ServiceDiscovery.cs
+++ b/src/ServiceDiscovery.cs
@@ -363,7 +363,7 @@ namespace Makaretu.Dns
             var msg = e.Message;
             if (log.IsDebugEnabled)
             {
-                log.Debug($"Answer from {e.RemoteEndPoint}");
+                Console.WriteLine($"Answer from {e.RemoteEndPoint}");
             }
             if (log.IsTraceEnabled)
             {
@@ -413,7 +413,7 @@ namespace Makaretu.Dns
 
             if (log.IsDebugEnabled)
             {
-                log.Debug($"Query from {e.RemoteEndPoint}");
+                Console.WriteLine($"Query from {e.RemoteEndPoint}");
             }
             if (log.IsTraceEnabled)
             {
@@ -441,13 +441,11 @@ namespace Makaretu.Dns
 
             // Many bonjour browsers don't like DNS-SD response
             // with additional records.
-            if (response.Answers.Any(a => a.Name == ServiceName))
-            {
+            if (response.Answers.Any(a => a.Name == ServiceName)) {
                 response.AdditionalRecords.Clear();
             }
 
-            if (AnswersContainsAdditionalRecords)
-            {
+            if (AnswersContainsAdditionalRecords) {
                 response.Answers.AddRange(response.AdditionalRecords);
                 response.AdditionalRecords.Clear();
             }
@@ -469,7 +467,7 @@ namespace Makaretu.Dns
 
             if (log.IsDebugEnabled)
             {
-                log.Debug($"Sending answer");
+                Console.WriteLine($"Sending answer");
             }
             if (log.IsTraceEnabled)
             {

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -1,0 +1,16 @@
+{
+  "exclude": [
+    "**/bin",
+    "**/bower_components",
+    "**/jspm_packages",
+    "**/node_modules",
+    "**/obj",
+    "**/platforms"
+  ],
+  "Logging": {
+    "LogLevel": {
+      "Makaretu.Dns": "Trace",
+      "Default": "Trace"
+    }
+  }
+}


### PR DESCRIPTION
Adding the multicast socket options to an IPv4 interface would sometimes throw an "A socket operation was attempted to an unreachable host.".

This was fixed by binding the multicast option to the address.