### PR TITLE
Add net462 and netstandard2.0 targets

### DIFF
--- a/src/Mdns.csproj
+++ b/src/Mdns.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462;netstandard2.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Makaretu.Dns.Multicast.New</AssemblyName>
     <RootNamespace>Makaretu.Dns</RootNamespace>

--- a/src/MulticastService.cs
+++ b/src/MulticastService.cs
@@ -261,7 +261,7 @@ namespace Makaretu.Dns
             AnswerReceived = null;
             NetworkInterfaceDiscovered = null;
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
             {
                 NetworkChange.NetworkAddressChanged -= OnNetworkAddressChanged;
             }
@@ -330,7 +330,7 @@ namespace Makaretu.Dns
                 // so no event). Rebinding fixes this.
                 //
                 // Do magic only on Windows.
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                if (Environment.OSVersion.Platform == PlatformID.Win32NT)
                 {
                     NetworkChange.NetworkAddressChanged -= OnNetworkAddressChanged;
                     NetworkChange.NetworkAddressChanged += OnNetworkAddressChanged;


### PR DESCRIPTION
This allows this project to be easily used from Standard/Framework projects.

4.6.2 is the baseline currently-supported Framework version: https://learn.microsoft.com/en-us/lifecycle/products/microsoft-net-framework