### PR TITLE
Changed Unicast and Multicast TTL to 255

### DIFF
--- a/src/MulticastClient.cs
+++ b/src/MulticastClient.cs
@@ -46,6 +46,8 @@ namespace Makaretu.Dns
             {
                 receiver4 = new UdpClient(AddressFamily.InterNetwork);
                 receiver4.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                receiver4.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.IpTimeToLive, 255);
+                receiver4.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastTimeToLive, 255);
                 receiver4.Client.Bind(new IPEndPoint(IPAddress.Any, MulticastPort));
                 receivers.Add(receiver4);
             }
@@ -55,6 +57,8 @@ namespace Makaretu.Dns
             {
                 receiver6 = new UdpClient(AddressFamily.InterNetworkV6);
                 receiver6.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                receiver6.Client.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IpTimeToLive, 255);
+                receiver6.Client.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.MulticastTimeToLive, 255);
                 receiver6.Client.Bind(new IPEndPoint(IPAddress.IPv6Any, MulticastPort));
                 receivers.Add(receiver6);
             }
@@ -81,6 +85,8 @@ namespace Makaretu.Dns
                             MulticastOption mcastOption4 = new MulticastOption(MulticastAddressIp4, address);
                             receiver4.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, mcastOption4);
                             sender.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                            sender.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.IpTimeToLive, 255);
+                            sender.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastTimeToLive, 255);
                             sender.Client.Bind(localEndpoint);
                             sender.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, mcastOption4);
                             break;
@@ -88,6 +94,8 @@ namespace Makaretu.Dns
                             IPv6MulticastOption mcastOption6 = new IPv6MulticastOption(MulticastAddressIp6, address.ScopeId);
                             receiver6.Client.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.AddMembership, mcastOption6);
                             sender.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                            sender.Client.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IpTimeToLive, 255);
+                            sender.Client.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.MulticastTimeToLive, 255);
                             sender.Client.Bind(localEndpoint);
                             sender.Client.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.AddMembership, mcastOption6);
                             break;

--- a/src/MulticastService.cs
+++ b/src/MulticastService.cs
@@ -128,10 +128,18 @@ namespace Makaretu.Dns
 
             UseIpv4 = Socket.OSSupportsIPv4;
             if (UseIpv4)
+            {
                 unicastClientIp4 = new UdpClient(AddressFamily.InterNetwork);
+                unicastClientIp4.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.IpTimeToLive, 255);
+                unicastClientIp4.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastTimeToLive, 255);
+            }
             UseIpv6 = Socket.OSSupportsIPv6;
             if (UseIpv6)
+            {
                 unicastClientIp6 = new UdpClient(AddressFamily.InterNetworkV6);
+                unicastClientIp6.Client.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IpTimeToLive, 255);
+                unicastClientIp6.Client.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.MulticastTimeToLive, 255);
+            }
             IgnoreDuplicateMessages = true;
         }
 


### PR DESCRIPTION
Complying to [RFC 6762 Section 11](https://www.rfc-editor.org/rfc/rfc6762.html#section-11)

> All Multicast DNS responses (including responses sent via unicast) SHOULD be sent with IP TTL set to 255.