### PR TITLE
Support all IPv6 multicast address scopes

### DIFF
--- a/Browser/Browser.csproj
+++ b/Browser/Browser.csproj
@@ -9,8 +9,4 @@
     <ProjectReference Include="..\src\Mdns.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
-
 </Project>

--- a/src/IPv6MulticastAddressScope.cs
+++ b/src/IPv6MulticastAddressScope.cs
@@ -1,0 +1,43 @@
+﻿namespace Makaretu.Dns
+{
+    /// <summary>
+    /// The IPv6 multicast address scopes.
+    /// </summary>
+    public enum IPv6MulticastAddressScope
+    {
+        /// <summary>
+        /// The Interface-Local IPv6 multicast address scope.
+        /// </summary>
+        InterfaceLocal = 1,
+
+        /// <summary>
+        /// The Link-Local IPv6 multicast address scope.
+        /// </summary>
+        LinkLocal = 2,
+
+        /// <summary>
+        /// The Realm-Local IPv6 multicast address scope.
+        /// </summary>
+        RealmLocal = 3,
+
+        /// <summary>
+        /// The Admin-Local IPv6 multicast address scope.
+        /// </summary>
+        AdminLocal = 4,
+
+        /// <summary>
+        /// The Site-Local IPv6 multicast address scope.
+        /// </summary>
+        SiteLocal = 5,
+
+        /// <summary>
+        /// The Organization-Local IPv6 multicast address scope.
+        /// </summary>
+        OrganizationLocal = 8,
+
+        /// <summary>
+        /// The Global IPv6 multicast address scope.
+        /// </summary>
+        Global = 14
+    }
+}


### PR DESCRIPTION
This PR includes changes to enhance IPv6 multicast to support different scopes. Per definition it's valid for any IPv6 address to respond to any multicast scope. By default we match as follows:
- IPv6 loopback address -> interface-local multicast scope (FF01::FB)
- Any link-local IPv6 address -> link-local multicast scope (FF02::FB)
- Any site-local IPv6 address (deprecated since 2004) -> site-local multicast scope (FF05::FB)
- Any other IPv6 address -> global multicast scope (FF0E::FB)

In addition, I renamed some fields to match the [.NET naming conventions](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/identifier-names), especially:
> - Use PascalCase for constant names, both fields and local constants.
> - Private instance fields start with an underscore (_) and the remaining text is camelCased.

Also, I added missing access modifiers and applied a couple of compiler suggestions.
